### PR TITLE
fix inconsistent trailing slash

### DIFF
--- a/components/IssueLink.vue
+++ b/components/IssueLink.vue
@@ -1,6 +1,6 @@
 <template>
   <v-list-tile
-    :to="{ name: 'issue-id', params: { id:milestone.title }}"
+    :to="`issue/${milestone.title}/`"
     nuxt >
     <v-list-tile-content>
       <v-list-tile-title v-html="title"/>


### PR DESCRIPTION
トップからissueに遷移すると `issue/10-xxxxxxxx-xxxxxxxx` だが、issueに直で遷移したりリロードすると `issue/10-xxxxxxxx-xxxxxxxx/` になってしまう件の対応

かならず `issue/10-xxxxxxxx-xxxxxxxx/` 形式で遷移するように変更