### PR TITLE
include description in title

### DIFF
--- a/pages/issue/_id.vue
+++ b/pages/issue/_id.vue
@@ -111,7 +111,11 @@ export default class Issue extends Vue {
   baseUrl!: string;
 
   head() {
-    const title = `${this.title} - ${this.siteTitle}`;
+    let titleDescription = '';
+    if (this.milestone.description) {
+      titleDescription = `: ${this.milestone.description}`
+    }
+    const title = `${this.title}${titleDescription} - ${this.siteTitle}`;
 
     return {
       title: title,


### PR DESCRIPTION
```
#39-20181021-20181027: Robolectric 4.0リリース、Kotlin 1.3でコーディングスタイルが更新される、Android Studio 3.4 Canary 2がリリース、など。 - Android Dagashi
```

直近のだとこんな感じです。
マイルストーンの説明がないと、今までどおり

```
#1-20180128-20180203 - Android Dagashi
```

フォーマットなにか案ありますかね？