### PR TITLE
chore(ci): migrate GitHub Pages deploy to official actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,20 +6,17 @@ on:
       - development
 
 jobs:
-  deploy_site:
-    name: Deploy Website
+  build:
+    name: Build Website
     runs-on: ubuntu-latest
     env:
       TZ: Asia/Tokyo
       GH_READONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PROJECT_USER_NAME: AndroidDagashi
-      PROJECT_REPO_NAME: androiddagashi.github.io
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: development
-          persist-credentials: false
 
       # run corepack before setup mise
       # https://github.com/actions/setup-node/issues/899
@@ -37,18 +34,22 @@ jobs:
       - name: Generate website
         run: yarn workspace site exec nuxi build --preset github_pages
 
-      - name: Deploy website
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          personal_token: ${{ secrets.PUSH_ACCESS_TOKEN }}
-          publish_dir: ./packages/site/.output/public
-          publish_branch: master
-          force_orphan: true
-          user_name: 'AndroidDagashi store staff'
-          user_email: 'androiddagashi-bot@users.noreply.github.com'
+          path: ./packages/site/.output/public
 
-      - name: Print debug info
-        if: failure()
-        run: |
-          git remote
-          git status
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary
- `peaceiris/actions-gh-pages` を GitHub 公式の `actions/upload-pages-artifact@v5` + `actions/deploy-pages@v5` に置き換え
- デプロイ時の `PUSH_ACCESS_TOKEN` (PAT) 依存を排除し、`GITHUB_TOKEN` の組み込み権限のみで動作するように変更
- build / deploy ジョブを分離（GitHub 公式推奨パターン）

## Test plan
- [ ] GitHub リポジトリの Settings > Pages > Source が「GitHub Actions」に設定済みであることを確認
- [ ] development ブランチへマージ後、GitHub Actions の deploy ワークフローが正常に完了することを確認
- [ ] デプロイ後、https://androiddagashi.github.io/ が正常に表示されることを確認
- [ ] GitHub の Environments UI に `github-pages` 環境が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)