### PR TITLE
fix: remove wildcard from packageRules matchPackageNames

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,6 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchPackageNames": [
-        "*",
         "!vue-server-renderer",
         "!vue-template-compiler",
         "!@nuxtjs/tailwindcss"


### PR DESCRIPTION
## 概要

Renovate の設定エラー (#654) を修正する。

`renovate.json` の `packageRules[0].matchPackageNames` に `"*"` と否定パターン (`!`) が混在しており、Renovate の新しいバリデーションでエラーになっていた。

```
packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns.
Please remove them, as * or ** matches all patterns.
```

## 変更内容

- `matchPackageNames` から `"*"` を削除

否定パターン (`!`) のみの場合、Renovate は「それら以外のすべてのパッケージ」にマッチするため、意図した挙動（vue-server-renderer / vue-template-compiler / @nuxtjs/tailwindcss を除く全パッケージの minor/patch をグループ化）はそのまま維持される。

## 確認

- `renovate-config-validator` でバリデーション成功を確認

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)