### PR TITLE
fix(site): vue-tsc の null 安全性エラー修正と typecheck CI ゲート追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Lint
         run: yarn site:lint
 
+      - name: Typecheck
+        run: yarn site:typecheck
+
       - name: Generate website
         run: yarn workspace site exec nuxi build --preset github_pages

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "site:generate": "yarn workspace site generate",
     "sns:update": "yarn workspace sns-updater update",
     "site:lint": "yarn workspace site lint",
-    "site:format": "yarn workspace site format"
+    "site:format": "yarn workspace site format",
+    "site:typecheck": "yarn workspace site typecheck"
   },
   "private": true,
   "workspaces": [

--- a/packages/site/app/plugins/2.gtag.ts
+++ b/packages/site/app/plugins/2.gtag.ts
@@ -12,7 +12,8 @@ export default defineNuxtPlugin((_nuxtApp) => {
   newTag.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`
 
   const existingTag = document.getElementsByTagName('script')[0]
-  existingTag.parentNode!.insertBefore(newTag, existingTag)
+  if (!existingTag?.parentNode) return
+  existingTag.parentNode.insertBefore(newTag, existingTag)
 
   // @ts-expect-error: dataLayer is defined in the global scope
   window.dataLayer = window.dataLayer || []

--- a/packages/site/app/plugins/4.markdownit.ts
+++ b/packages/site/app/plugins/4.markdownit.ts
@@ -21,22 +21,28 @@ export default defineNuxtPlugin((_nuxtApp) => {
     })
 
   md.renderer.rules.link_open = (tokens, idx, options, env, self): string => {
-    const aIndex = tokens[idx].attrIndex('target')
+    const token = tokens[idx]
+    if (!token) return defualtLinkRenderer(tokens, idx, options, env, self)
+
+    const aIndex = token.attrIndex('target')
 
     if (aIndex < 0) {
-      tokens[idx].attrPush(['target', '_blank'])
-    } else {
-      tokens[idx].attrs![aIndex][1] = '_blank'
+      token.attrPush(['target', '_blank'])
+    } else if (token.attrs) {
+      token.attrs[aIndex]![1] = '_blank'
     }
 
     return defualtLinkRenderer(tokens, idx, options, env, self)
   }
 
   md.renderer.rules.image = (tokens, idx, options, env, self): string => {
-    const styleIndex = tokens[idx].attrIndex('style')
+    const token = tokens[idx]
+    if (!token) return defaultStyleRenderer(tokens, idx, options, env, self)
+
+    const styleIndex = token.attrIndex('style')
 
     if (styleIndex < 0) {
-      tokens[idx].attrPush(['style', 'max-width: 100%;'])
+      token.attrPush(['style', 'max-width: 100%;'])
     }
 
     return defaultStyleRenderer(tokens, idx, options, env, self)

--- a/packages/site/app/utils/sharewidget-scripts.ts
+++ b/packages/site/app/utils/sharewidget-scripts.ts
@@ -17,7 +17,7 @@ const loadScript = (document: Document, id: string, src: string) => {
   script.id = id
 
   const s = document.getElementsByTagName('script')[0]
-  s.parentNode?.insertBefore(script, s)
+  s?.parentNode?.insertBefore(script, s)
 }
 
 export const loadScripts = (document: Document): void => {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -10,7 +10,8 @@
     "preview": "nuxi preview",
     "postinstall": "nuxi prepare",
     "lint": "eslint .",
-    "format": "eslint --fix ."
+    "format": "eslint --fix .",
+    "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
     "@pinia/nuxt": "0.11.3",

--- a/packages/site/tsconfig.json
+++ b/packages/site/tsconfig.json
@@ -4,6 +4,6 @@
     "noImplicitAny": false,
     "noUnusedParameters": false,
     "strictNullChecks": true,
-    "types": ["@types/node", "@nuxt/types", "@pinia/nuxt"]
+    "types": ["@types/node", "@pinia/nuxt"]
   }
 }


### PR DESCRIPTION
## 概要

Closes #623

`vue-tsc --noEmit` が報告する null 安全性エラーを修正し、今後同種の借金を CI でゲートできるようにする。

## 変更内容

### null 安全性エラーの修正
- **`packages/site/app/plugins/2.gtag.ts`** — `existingTag?.parentNode` の早期 return ガードを追加
- **`packages/site/app/plugins/4.markdownit.ts`** — `link_open` / `image` レンダラーで `tokens[idx]` を変数化して undefined ガード、`attrs` の存在チェックを追加
- **`packages/site/app/utils/sharewidget-scripts.ts`** — `s?.parentNode?.insertBefore(...)` に変更

### 付随する設定の不具合修正
- **`packages/site/tsconfig.json`** — Nuxt 3 移行時 (`ffa68c94`) に package.json から削除済みだった Nuxt 2 用 `@nuxt/types` の死んだ参照が `types` 配列に残っており、vue-tsc が `TS2688` で起動すらできない状態だったため除去

### typecheck の CI ゲート追加
- **`packages/site/package.json`** — `typecheck` スクリプトを追加
- **`package.json` (ルート)** — `site:typecheck` エイリアスを追加
- **`.github/workflows/build.yml`** — PR で走る CI に `Typecheck` ステップを追加 (deploy.yml には追加しない)

## 検証

\`\`\`
$ yarn site:typecheck   # → exit 0 (0 errors)
$ yarn workspace site lint   # → pass
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)