### PR TITLE
fix(site): Markdown の code/pre 要素にスタイルを適用 (#326)

### DIFF
--- a/packages/site/app/components/atoms/MarkdownText/index.vue
+++ b/packages/site/app/components/atoms/MarkdownText/index.vue
@@ -54,4 +54,32 @@ export default defineComponent({
   color: #6a737d;
   border-left: 0.25em solid #dfe2e5;
 }
+
+.markdown-text :deep(code) {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+    'Liberation Mono', monospace;
+  background-color: rgba(175, 184, 193, 0.2);
+  border-radius: 6px;
+}
+
+.markdown-text :deep(pre) {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+}
+
+.markdown-text :deep(pre code) {
+  padding: 0;
+  margin: 0;
+  font-size: 100%;
+  background-color: transparent;
+  border-radius: 0;
+}
 </style>


### PR DESCRIPTION
## 概要

Markdown レンダリング（markdown-it）で生成される `<code>` / `<pre>` 要素にスタイルが当たっていなかった問題を修正します。

Closes #326

## 変更内容

`packages/site/app/components/atoms/MarkdownText/index.vue` のスタイルブロックに GitHub 風の code スタイルを追加しました。

- **インライン `<code>`** — 薄いグレー背景・パディング・角丸・等幅フォント・85% サイズ
- **`<pre>`（コードブロック）** — `#f6f8fa` 背景・パディング・横スクロール対応
- **`<pre code>`** — ブロック内の code はインライン用の背景/角丸をリセット（背景の二重適用を防止）

markdown-it プラグイン側の変更は不要でした。

## 確認方法

コードブロックを含む既存記事で見た目を確認:

- `/issue/73` — Kotlin/Native の gradle コードブロック2つ
- `/issue/22` — Slices Builders KTX の kotlin DSL
- `/issue/16` — LiveData の kotlin コードブロック

## テスト

- [x] `yarn site:lint` 通過
- [x] dev サーバーで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)