### PR TITLE
fix(site): 記事詳細の useAsyncData 警告と CSR 遷移時の表示不具合を修正

### DIFF
--- a/packages/site/app/pages/issue/[id].vue
+++ b/packages/site/app/pages/issue/[id].vue
@@ -43,7 +43,15 @@ export default defineComponent({
 
     const issueStore = useIssueStore()
 
-    const currentMilestone = computed(() => issueStore.currentMilestone)
+    // Nuxt 4: composable (useAsyncData / useHead) は await の前に呼ぶ必要がある。
+    // 描画ソースは useAsyncData が返す data ref。watch によりナビゲーション/
+    // キャッシュ命中時も正しく更新される。
+    const milestoneData = useAsyncData(
+      `issue-${route.params.id}`,
+      () => issueStore.fetchById(route.params.id as string),
+      { watch: [() => route.params.id] }
+    )
+    const currentMilestone = milestoneData.data
 
     const milestoneTitle = computed(() => currentMilestone.value?.title ?? '')
     const milestoneDescription = computed(
@@ -51,7 +59,6 @@ export default defineComponent({
     )
     const issues = computed(() => currentMilestone.value?.issues?.nodes ?? [])
 
-    // Nuxt 4: composable は await の前に呼ぶ必要がある
     useHead(
       computed(() => {
         const newTitle = `${milestoneTitle.value}: ${milestoneDescription.value} - ${app.$config.public.title}`
@@ -72,12 +79,8 @@ export default defineComponent({
 
     onMounted(() => loadScripts(document))
 
-    // Nuxt 4: useAsyncData で route.params.id を watch してナビゲーション時に再取得
-    await useAsyncData(
-      `issue-${route.params.id}`,
-      () => issueStore.fetchById(route.params.id as string),
-      { watch: [() => route.params.id] }
-    )
+    // データ取得完了を待つ (SSR / 初回描画用)
+    await milestoneData
 
     return {
       currentMilestone,

--- a/packages/site/app/store/issue.ts
+++ b/packages/site/app/store/issue.ts
@@ -2,42 +2,11 @@ import { defineStore } from 'pinia'
 import type { GHMilestone } from 'site-types/GitHubApi'
 import { useNuxtApp } from '#app'
 
-interface IssueState {
-  currentMilestoneId: string | null
-  milestones: { [milestoneId: string]: GHMilestone }
-}
-
 export const useIssueStore = defineStore('issue', {
-  state: (): IssueState => ({
-    currentMilestoneId: null,
-    milestones: {},
-  }),
-
-  getters: {
-    currentMilestone: (state): GHMilestone | null => {
-      const milestoneId = state.currentMilestoneId
-      if (milestoneId) {
-        return state.milestones[milestoneId] ?? null
-      }
-      return null
-    },
-  },
-
   actions: {
-    updateCurrentMilestone(milestoneId: string) {
-      this.currentMilestoneId = milestoneId
-    },
-
-    addMilestone(milestoneId: string, milestone: GHMilestone) {
-      this.milestones = {
-        ...this.milestones,
-        [milestoneId]: milestone,
-      }
-    },
-
-    async fetchById(milestoneId: string) {
-      this.updateCurrentMilestone(milestoneId)
-
+    // milestone を取得し minimized コメントを除外して返す純粋な fetch。
+    // キャッシュは呼び出し側の useAsyncData (key 単位) が担うため store では保持しない。
+    async fetchById(milestoneId: string): Promise<GHMilestone> {
       const { $api } = useNuxtApp()
       let milestone = await $api.get<GHMilestone>(
         `/api/issue/${milestoneId}.json`
@@ -62,7 +31,7 @@ export const useIssueStore = defineStore('issue', {
         },
       }
 
-      this.addMilestone(milestoneId, milestone)
+      return milestone
     },
   },
 })


### PR DESCRIPTION
## 概要

記事詳細ページ (`packages/site/app/pages/issue/[id].vue`) で発生していた以下を修正します。

1. dev サーバ起動時の Nuxt 警告
   `[nuxt] useAsyncData ... must return a value (it should not be undefined) or the request may be duplicated on the client side.`
2. CSR 遷移時の表示不具合
   - トップ → 記事詳細へ CSR 遷移すると記事が空表示になる
   - 記事詳細でリロードすると表示されるが、別の記事へ遷移しても最初にリロードした記事が表示され続ける（stale）

## 原因

このページは `useAsyncData` の戻り値ではなく、Pinia store の getter `currentMilestone`（`fetchById` の副作用で `currentMilestoneId` が更新されることに依存）を描画ソースにしていた。

`useAsyncData` のハンドラが値を返していなかった（警告の原因）うえ、結果を返すようにするとキャッシュ命中時に Nuxt がハンドラ実行をスキップし、`fetchById` の副作用が走らず `currentMilestoneId` が更新されない → 空表示 / stale 表示につながっていた。

## 修正内容

- `store/issue.ts`: `fetchById` を副作用なしの純粋 fetch にして `milestone` を返すよう変更。キャッシュは呼び出し側の `useAsyncData`（key 単位）に一本化し、不要になった state / getter / action（`currentMilestoneId`, `currentMilestone`, `updateCurrentMilestone`, `addMilestone`, `milestones` cache）を削除。
- `[id].vue`: 描画ソースを `useAsyncData` が返す `data` ref に直接ひも付け。`watch: [() => route.params.id]` によりナビゲーション/キャッシュ命中時も正しく更新される。`useAsyncData` / `useHead` は `await` の前に呼ぶ順序を維持。

## 確認

- `yarn site:typecheck` ✅
- `yarn site:lint` ✅
- dev サーバでの CSR 遷移・リロード時の表示確認（要・手元での動作確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)