### PR TITLE
fix(site): hide empty comment section when all comments are minimized

### DIFF
--- a/packages/site/app/components/organisms/LinkItem/index.vue
+++ b/packages/site/app/components/organisms/LinkItem/index.vue
@@ -54,7 +54,9 @@ export default defineComponent({
   setup(props) {
     const hasLabels = computed(() => props.issue.labels.nodes.length > 0)
     const labels = computed(() => props.issue.labels.nodes)
-    const hasComments = computed(() => props.issue.comments.totalCount > 0)
+    // totalCount は minimized コメントも含む GitHub 上の総数なので表示判定には使えない
+    // (store 側で minimized コメントを nodes から除外している)
+    const hasComments = computed(() => props.issue.comments.nodes.length > 0)
     const comments = computed(() => props.issue.comments.nodes)
 
     return {


### PR DESCRIPTION
## Summary
- `LinkItem` の `hasComments` が `comments.totalCount > 0` で判定されていたが、`totalCount` は minimized コメントを含む GitHub 上の総数であり、store (`app/store/issue.ts`) でフィルタされる `comments.nodes` とずれる
- 全コメントが minimized な issue では、コメントが 1 件も表示されないのに空の枠線 (`border-t`) と余白だけが描画されていた
- 判定を `comments.nodes.length > 0` に変更し、`totalCount` が使えない理由をコメントとして明記

## Test plan
- [ ] `yarn api:generate` 後に `yarn site:dev` を起動し、全コメントが minimized な issue を含む milestone ページで空のコメント枠が表示されないことを確認
- [ ] 通常のコメントがある issue でコメントが従来どおり表示されることを確認
- [x] 変更ファイルに対して ESLint を実行しエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpBbE4KKQ9gQEvk9rDAg68