### PR TITLE
refactor(site): replace @apply with template utility classes

### DIFF
--- a/packages/site/app/components/organisms/IssueDigestList/index.vue
+++ b/packages/site/app/components/organisms/IssueDigestList/index.vue
@@ -2,7 +2,9 @@
   <div class="IssueDigestList border border-gray-200 bg-white sm:rounded-md">
     <ul>
       <template v-for="(item, index) in milestones" :key="index">
-        <li class="IssueDigestList__item hover:bg-gray-100">
+        <li
+          class="IssueDigestList__item relative hover:bg-gray-100 after:absolute after:mx-[0.5em] after:h-px after:w-[calc(100%-3rem)] after:bg-gray-200 after:content-[''] last:after:hidden"
+        >
           <IssueDigest :milestone="item" :index="index" class="" />
         </li>
       </template>
@@ -28,20 +30,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="postcss" scoped>
-.IssueDigestList .IssueDigestList__item {
-  @apply relative;
-
-  &:not(:last-child):after {
-    content: '';
-    position: absolute;
-    width: calc(100% - 3rem);
-    height: 1px;
-    margin-right: 0.5em;
-    margin-left: 0.5em;
-
-    @apply bg-gray-200;
-  }
-}
-</style>

--- a/packages/site/app/components/organisms/LinkItem/LinkItemComment.vue
+++ b/packages/site/app/components/organisms/LinkItem/LinkItemComment.vue
@@ -1,5 +1,8 @@
 <template>
-  <component :is="tag" class="LinkItemComment py-1">
+  <component
+    :is="tag"
+    class="LinkItemComment relative py-1 before:absolute before:bottom-0 before:left-[18px] before:top-12 before:w-0.5 before:bg-gray-300 before:content-['']"
+  >
     <aside>
       <a :href="comment.author.url" target="_blank">
         <ADAvatar
@@ -50,19 +53,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="postcss" scoped>
-.LinkItemComment {
-  @apply relative;
-
-  &::before {
-    @apply absolute bg-gray-300;
-
-    content: '';
-    top: 48px;
-    bottom: 0px;
-    left: 18px;
-    width: 2px;
-  }
-}
-</style>

--- a/packages/site/app/components/organisms/LinkItem/index.vue
+++ b/packages/site/app/components/organisms/LinkItem/index.vue
@@ -18,7 +18,11 @@
         </template>
       </ul>
     </div>
-    <a :href="issue.url" target="_blank" class="LinkItem__GitHubLink">
+    <a
+      :href="issue.url"
+      target="_blank"
+      class="LinkItem__GitHubLink mt-1 inline-flex h-8 items-center rounded-full border border-solid border-gray-300 px-5 text-sm font-semibold text-gray-400 hover:bg-gray-100"
+    >
       <span>GitHubで見る</span>
     </a>
   </ADCard>
@@ -68,10 +72,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="postcss" scoped>
-.LinkItem__GitHubLink {
-  @apply mt-1 inline-flex h-8 items-center rounded-full border border-solid border-gray-300 px-5 text-sm font-semibold text-gray-400;
-  @apply hover:bg-gray-100;
-}
-</style>

--- a/packages/site/app/components/organisms/SiteDescription/index.vue
+++ b/packages/site/app/components/organisms/SiteDescription/index.vue
@@ -16,7 +16,11 @@
     </p>
     <p>おおよそ毎週日曜夜の更新です。</p>
     <div class="mt-6">
-      <a class="FollowOnTwitter" :href="dagashiTwitterUrl" target="_blank">
+      <a
+        class="FollowOnTwitter inline-flex h-12 items-center space-x-3 rounded-md bg-[#1d9bf0] px-6 text-white shadow-md"
+        :href="dagashiTwitterUrl"
+        target="_blank"
+      >
         <iconify-icon icon="akar-icons:twitter-fill" width="24" />
         <span class="font-bold">Follow @{{ contact.name }}</span>
       </a>
@@ -71,11 +75,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="postcss" scoped>
-.FollowOnTwitter {
-  @apply inline-flex h-12 items-center space-x-3 rounded-md px-6 text-white shadow-md;
-
-  background-color: #1d9bf0;
-}
-</style>

--- a/packages/site/app/pages/index.vue
+++ b/packages/site/app/pages/index.vue
@@ -3,7 +3,10 @@
     <h2 class="px-3 font-roboto text-2xl font-semibold">ISSUES</h2>
     <IssueDigestList class="mt-3" :milestones="milestones">
       <template v-if="pageInfo?.hasNextPage" #bottom>
-        <button class="LoadNextButton" @click="onLoadNext">
+        <button
+          class="LoadNextButton relative flex h-12 w-full flex-row items-center justify-center hover:bg-gray-100 before:absolute before:top-0 before:mx-[0.5em] before:h-px before:w-[calc(100%-3rem)] before:bg-gray-200 before:content-['']"
+          @click="onLoadNext"
+        >
           <iconify-icon icon="ic:baseline-expand-more" width="24" />
           <span class="sr-only"> 次の記事を読み込む </span>
         </button>
@@ -62,22 +65,3 @@ export default defineComponent({
   },
 })
 </script>
-
-<style lang="postcss" scoped>
-.LoadNextButton {
-  @apply relative flex h-12 w-full flex-row items-center justify-center;
-  @apply hover:bg-gray-100;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    width: calc(100% - 3rem);
-    height: 1px;
-    margin-right: 0.5em;
-    margin-left: 0.5em;
-
-    @apply bg-gray-200;
-  }
-}
-</style>


### PR DESCRIPTION
## Summary
- Tailwind CSS v4 では `@apply` の使用が非推奨とされ、Vue SFC の `<style>` ブロック内で使うにはファイルごとに `@reference` 宣言が必要になるため、将来の v4 移行に先立って `@apply` を全廃した
- 5コンポーネント・10箇所の `@apply` をテンプレート内のユーティリティクラスへ移行（擬似要素は `before:`/`after:` バリアント + arbitrary value で置き換え）し、`<style>` ブロックを削除
- `IssueDigestList__item` の区切り線は `:not(:last-child):after` から「全項目に `after:` を適用し `last:after:hidden` で最後だけ非表示」に変更（視覚的に等価）
- `LinkItemComment` や `LoadNextButton` などのクラス名はマーカーとして残している

## Test plan
- [x] `yarn site:lint` / `yarn site:format` がエラーなし
- [x] dev サーバーで SSR HTML に新しいクラスが出力されることを確認（トップページ・issue ページ）
- [x] 生成された Tailwind CSS に全ルールが存在し、宣言内容が元の CSS と等価（`top: 3rem`=48px、`width: calc(100% - 3rem)`、gray-200/300 の色値など）であることを確認
- [ ] デプロイプレビューまたはローカルで表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jt8uMjgq5q8TW8H52k6nd7