### PR TITLE
chore: update Node.js to v26.7.0

### DIFF
--- a/.devcontainer/mise/config.toml
+++ b/.devcontainer/mise/config.toml
@@ -1,4 +1,5 @@
 [tools]
 "node" = "24.19.0"
+"npm:@yarnpkg/cli-dist" = "4.18.0"
 "npm:@anthropic-ai/claude-code" = "2.1.228"
 "npm:@openai/codex" = "0.147.0"

--- a/.devcontainer/mise/config.toml
+++ b/.devcontainer/mise/config.toml
@@ -1,5 +1,5 @@
 [tools]
-"node" = "24.19.0"
+"node" = "26.7.0"
 "npm:@yarnpkg/cli-dist" = "4.18.0"
 "npm:@anthropic-ai/claude-code" = "2.1.228"
 "npm:@openai/codex" = "0.147.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,17 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # run corepack before setup mise
-      # https://github.com/actions/setup-node/issues/899
-      - run: corepack enable yarn
-
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: install dependencies
         run: |
           node --version
-          corepack enable yarn
           yarn install
 
       - name: Lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,18 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache yarn packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
       - name: install dependencies
         run: |
           node --version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache yarn packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
       - name: install dependencies
         run: |
           node --version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,17 +18,12 @@ jobs:
         with:
           ref: development
 
-      # run corepack before setup mise
-      # https://github.com/actions/setup-node/issues/899
-      - run: corepack enable yarn
-
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: install dependencies
         run: |
           node --version
-          corepack enable yarn
           yarn install
 
       - name: Generate website

--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -26,17 +26,12 @@ jobs:
           ref: development
           persist-credentials: false
 
-      # run corepack before setup mise
-      # https://github.com/actions/setup-node/issues/899
-      - run: corepack enable yarn
-
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: install dependencies
         run: |
           node --version
-          corepack enable yarn
           yarn install
 
       - name: Setup git config

--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -29,6 +29,18 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache yarn packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
       - name: install dependencies
         run: |
           node --version

--- a/.github/workflows/update_sns.yml
+++ b/.github/workflows/update_sns.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache yarn packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
       - name: install dependencies
         run: |
           node --version

--- a/.github/workflows/update_sns.yml
+++ b/.github/workflows/update_sns.yml
@@ -28,17 +28,12 @@ jobs:
         with:
           ref: development
 
-      # run corepack before setup mise
-      # https://github.com/actions/setup-node/issues/899
-      - run: corepack enable yarn
-
       - name: Setup mise
         uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       - name: install dependencies
         run: |
           node --version
-          corepack enable yarn
           yarn install
 
       - name: setup Firebase

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -10,8 +10,8 @@
 ## Tech Stack
 - **Frontend**: Nuxt 4, Vue 3, Tailwind CSS, Pinia (state management)
 - **Language**: TypeScript (strict mode)
-- **Package Manager**: Yarn 4 with workspaces (PnP mode)
-- **Node.js**: v24.14.0 (managed via mise)
+- **Package Manager**: Yarn 4 with workspaces (`nodeLinker: node-modules`, not PnP; installed via mise)
+- **Node.js**: v26.7.0 (managed via mise)
 - **Build/Deploy**: GitHub Actions → GitHub Pages
 - **Code Quality**: ESLint, Prettier
 

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -4,6 +4,13 @@ ignore_all_files_in_gitignore: true
 
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
 # Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
@@ -14,51 +21,13 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "androiddagashi.github.io"
 
 # list of mode names to that are always to be included in the set of active modes
@@ -69,51 +38,29 @@ project_name: "androiddagashi.github.io"
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
 encoding: utf-8
-
-
-# list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Free Pascal/Lazarus, use pascal
-# Special requirements:
-#   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages:
-- typescript
 
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
@@ -147,6 +94,82 @@ ignored_memory_patterns: []
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   elixir
+#   elm                    erlang                 fortran                fsharp                 gdscript
+#   go                     groovy                 haskell                haxe                   hlsl
+#   html                   java                   json                   julia                  kotlin
+#   latex                  lean4                  lua                    luau                   markdown
+#   matlab                 msl                    nix                    ocaml                  pascal
+#   perl                   php                    php_phpactor           php_phpantom           powershell
+#   python                 python_basedpyright    python_jedi            python_pyrefly         python_ty
+#   qml                    r                      rego                   ruby                   ruby_solargraph
+#   rust                   scala                  scss                   solidity               svelte
+#   swift                  systemverilog          terraform              toml                   typescript
+#   typescript_vts         vue                    yaml                   zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of the LanguageServerId enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- typescript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ yarn sns:update               # Update social media with new content
 
 2. **Prerequisites**:
    - Node.js (managed via mise)
-   - Yarn 4 (via corepack)
+   - Yarn 4 (managed via mise; corepack is not bundled with Node 25+)
    - GitHub Personal Access Token (read-only permissions sufficient)
 
 ## Data Flow
@@ -69,8 +69,8 @@ yarn sns:update               # Update social media with new content
 
 - **nuxt.config.ts** - Main Nuxt configuration, defines routes from JSON data
 - **site-config** package - Shared configuration across workspaces
-- **mise.toml** - Node.js version management
-- **.yarnrc.yml** - Yarn 4 configuration with PnP mode
+- **mise.toml** - Node.js and Yarn version management
+- **.yarnrc.yml** - Yarn 4 configuration (`nodeLinker: node-modules`, not PnP)
 
 ## Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,4 @@
 
 bootstrap:
 	mise install
-	corepack enable yarn
 	yarn install

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "24.19.0"
+node = "26.7.0"
 # Yarn is installed via mise because corepack is no longer bundled with Node 25+.
 # Must keep in sync with `packageManager` in package.json.
 "npm:@yarnpkg/cli-dist" = "4.18.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [tools]
 node = "24.19.0"
+# Yarn is installed via mise because corepack is no longer bundled with Node 25+.
+# Must keep in sync with `packageManager` in package.json.
+"npm:@yarnpkg/cli-dist" = "4.18.0"

--- a/packages/site-api-github/package.json
+++ b/packages/site-api-github/package.json
@@ -10,7 +10,7 @@
     "@graphql-codegen/typescript": "6.1.0",
     "@graphql-codegen/typescript-document-nodes": "6.1.0",
     "@graphql-codegen/typescript-operations": "6.1.5",
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "graphql": "16.14.2",
     "site-types": "1.0.0",
     "tsx": "4.23.12",

--- a/packages/site-api/package.json
+++ b/packages/site-api/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "site-types": "1.0.0",
     "tsx": "4.23.12",
     "typescript": "6.0.3"

--- a/packages/site-common/package.json
+++ b/packages/site-common/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "typescript": "6.0.3"
   }
 }

--- a/packages/site-config/package.json
+++ b/packages/site-config/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "devDependencies": {
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "site-types": "1.0.0",
     "typescript": "6.0.3"
   }

--- a/packages/site-rss/package.json
+++ b/packages/site-rss/package.json
@@ -13,7 +13,7 @@
     "site-config": "1.0.0"
   },
   "devDependencies": {
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "site-types": "1.0.0",
     "tsx": "4.23.12",
     "typescript": "6.0.3"

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -31,7 +31,7 @@
     "@nuxt/eslint": "1.17.0",
     "@tailwindcss/vite": "4.3.3",
     "@types/lodash": "4.17.25",
-    "@types/node": "24.13.3",
+    "@types/node": "26.2.0",
     "@types/twitter-text": "3.1.10",
     "eslint": "10.8.1",
     "site-types": "1.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -25,12 +25,27 @@
       ]
     },
     {
+      "description": [
+        "Node 26 は 2026-10 に LTS 化予定の Current だが、本プロジェクトは静的サイト生成で Node はビルド時にしか動作しないためリスク限定的と判断し先行採用する。",
+        "27 系（2027-04 予定）へ自動追随しないよう上限は 26 に固定する。"
+      ],
       "matchPackageNames": [
         "node",
         "@types/node"
       ],
-      "allowedVersions": "<=24",
+      "allowedVersions": "<=26",
       "groupName": "Node.js"
+    },
+    {
+      "description": [
+        "Node 25 以降 corepack が Node に同梱されなくなったため、Yarn は mise の npm backend (npm:@yarnpkg/cli-dist) で調達している。",
+        "mise.toml の @yarnpkg/cli-dist と package.json の packageManager は同じバージョンを保つ必要があるため、同一 PR に束ねてドリフトを防ぐ。"
+      ],
+      "matchPackageNames": [
+        "@yarnpkg/cli-dist",
+        "yarn"
+      ],
+      "groupName": "Yarn"
     },
     {
       "matchPackageNames": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,21 +3592,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0":
+"@types/node@npm:*, @types/node@npm:26.2.0, @types/node@npm:>=13.7.0":
   version: 26.2.0
   resolution: "@types/node@npm:26.2.0"
   dependencies:
     undici-types: "npm:~8.3.0"
   checksum: 10c0/f8566d88162241eb55a46f7e4ea097188eab0aaafefea7a58e63adab8c4144eb98c08b7911452c846104c339a0f82282f5e1ed4b26b578d60709614fe2843f4d
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:24.13.3":
-  version: 24.13.3
-  resolution: "@types/node@npm:24.13.3"
-  dependencies:
-    undici-types: "npm:~7.18.0"
-  checksum: 10c0/a5bc08f49b9581dcdca90e02cd77197a3c799840807664942e5cd5161a553d4d2ae8064f7e3294410d748d7d098b5c1848be7fa50c06f29c4193ab16be4e59eb
   languageName: node
   linkType: hard
 
@@ -10986,7 +10977,7 @@ __metadata:
     "@graphql-codegen/typescript-document-nodes": "npm:6.1.0"
     "@graphql-codegen/typescript-operations": "npm:6.1.5"
     "@octokit/graphql": "npm:9.0.4"
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     graphql: "npm:16.14.2"
     site-common: "npm:1.0.0"
     site-types: "npm:1.0.0"
@@ -11000,7 +10991,7 @@ __metadata:
   resolution: "site-api@workspace:packages/site-api"
   dependencies:
     "@types/fs-extra": "npm:11.0.4"
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     fs-extra: "npm:11.4.0"
     rimraf: "npm:6.1.3"
     site-api-github: "npm:1.0.0"
@@ -11016,7 +11007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "site-common@workspace:packages/site-common"
   dependencies:
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
@@ -11025,7 +11016,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "site-config@workspace:packages/site-config"
   dependencies:
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     site-types: "npm:1.0.0"
     typescript: "npm:6.0.3"
   languageName: unknown
@@ -11035,7 +11026,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "site-rss@workspace:packages/site-rss"
   dependencies:
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     feed: "patch:feed@npm%3A5.2.0#~/.yarn/patches/feed-npm-5.2.0-a770610f78.patch"
     markdown-it: "npm:15.0.0"
     site-common: "npm:1.0.0"
@@ -11062,7 +11053,7 @@ __metadata:
     "@tailwindcss/forms": "npm:0.5.11"
     "@tailwindcss/vite": "npm:4.3.3"
     "@types/lodash": "npm:4.17.25"
-    "@types/node": "npm:24.13.3"
+    "@types/node": "npm:26.2.0"
     "@types/twitter-text": "npm:3.1.10"
     date-fns: "npm:4.4.0"
     eslint: "npm:10.8.1"
@@ -11853,13 +11844,6 @@ __metadata:
     unplugin:
       optional: true
   checksum: 10c0/64a8d85b24d00d6d85e2420e48d68f5827535f8ed54009a4eb00181952fd43e8d783d2c377f8bcf479467c0541d4485866458e83781438cc55bb9dbe26ca9268
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~7.18.0":
-  version: 7.18.2
-  resolution: "undici-types@npm:7.18.2"
-  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要

Node.js を `24.19.0` → **`26.7.0`** に更新する。

v26.7.0 は 2026-08-05 リリース。Node 26 は 2026-10 に LTS 化予定の Current だが、本プロジェクトは GitHub Pages 向けの静的サイト生成で Node はビルド時にしか動作しない（デプロイ成果物は静的 HTML/JS のみ）ため、リスク限定的と判断して先行採用する。

## ⚠️ 単純なバージョン差し替えでは済まなかった点

**Node.js は v25.0.0 で corepack の同梱配布を停止した**（[TSC 決議](https://socket.dev/blog/node-js-tsc-votes-to-stop-distributing-corepack)）。Node 26 の tarball に `corepack` バイナリは存在しない。

一方このリポジトリは Yarn 4 の起動を完全に corepack に依存していた（計9箇所）:

- `Makefile:5`
- `.github/workflows/{build,deploy,update_api,update_sns}.yml` — 各2箇所

そのため `mise.toml` の1行を書き換えるだけでは **CI 4本すべてと `make bootstrap` が `corepack: command not found` で即死する**。本 PR の中心は Yarn の入手経路を corepack から mise へ移すことにある。

ローカルで Node 26.7.0 をインストールして `command -v corepack` が空になること、それでも mise 経由の Yarn 4.18.0 が動作することを実機確認済み。

### なぜ `npm:@yarnpkg/cli-dist` なのか

- Renovate の mise manager は [`npm:` backend をサポートする一方、`vfox:` / `asdf:` のプラグイン短縮参照には非対応](https://docs.renovatebot.com/modules/manager/mise/)。mise registry の bare `yarn` は `vfox:mise-plugins/vfox-yarn` に解決されるため、`yarn = "4.18.0"` と書くと Renovate が追随できなくなる
- `@yarnpkg/cli-dist@4.18.0` は bin として `yarn` / `yarnpkg` を提供し、`packageManager: yarn@4.18.0` とバージョンが一致する
- install / postinstall スクリプトを持たない

## 変更内容

| # | コミット | 内容 |
|---|---|---|
| 1 | `build: manage Yarn via mise instead of corepack` | `mise.toml` に `npm:@yarnpkg/cli-dist` 追加、corepack 参照9箇所を削除 |
| 2 | `ci: cache yarn packages` | 4ワークフローに `actions/cache` を追加 |
| 3 | `chore(deps): update node.js to v26.7.0` | `mise.toml` / devcontainer の2行 |
| 4 | `chore(deps): update @types/node to v26.2.0` | 6パッケージ + `yarn.lock` |
| 5 | `chore(renovate): allow Node.js 26 and group Yarn updates` | `allowedVersions` を `<=26` へ、Yarn グループ追加 |
| 6 | `docs: fix stale Node version and PnP misstatement` | `AGENTS.md` / serena memory |
| 7 | `chore(serena): migrate project.yml to the current schema` | 作業前から残っていた無関係な差分（別コミットに分離） |

コミット 1〜2 は **Node 24 のままでも green** になるので、3 が純粋な Node バージョン変更として独立する。

### 副次的な改善

- **`yarn.lock` の分裂を解消。** 従来 `@types/node` は推移的依存が要求する `*, >=13.7.0` が 26.2.0、pin 分が 24.13.3 に割れ、実体2つ・`undici-types` も `~7.18.0` / `~8.3.0` の2系統が同居していた。pin を揃えたことで **lock エントリ1本 / 実体1つ / `undici-types` `~8.3.0` のみ**に収束
- **CI の依存キャッシュを新規追加。** `jdx/mise-action` は `cache: true` がデフォルトなのでツール本体は既にキャッシュされていたが、Yarn がダウンロードするパッケージ zip は未キャッシュだった。パスはハードコードせず `yarn config get cacheFolder` から動的取得（Yarn 4 はグローバルキャッシュがデフォルト有効で実体は `~/.yarn/berry/cache`）
- 各ワークフローの `actions/setup-node#899` 回避コメント付き二重 corepack 実行を削除。**このリポジトリは `actions/setup-node` を使っておらず**（`jdx/mise-action` のみ）痕跡コードだった
- `AGENTS.md` の「`.yarnrc.yml` - Yarn 4 configuration with **PnP mode**」は誤記だった。実際は `nodeLinker: node-modules`

## 互換性検証

- `engines.node` を宣言する **139 パッケージのうち上限を持つものは 0 件**。`cssnano` / `postcss-*` 系は `^22.11.0 || ^24.11.0 || >=26.0` と 26 を明示列挙済み
- ネイティブモジュールは全て N-API prebuilt のため、`NODE_MODULE_VERSION` の 147 への変更でも node-gyp ビルドは発生しない
- Node 26 で削除された API（`_stream_*`, `http.writeHeader()`, `createCipher()`）の使用は **0 件**
- `.yarn/patches/feed-npm-5.2.0-*.patch` は拡張子付き `.js` なので `type:module` の拡張子なし CJS 例外削除に該当しない

## ローカル検証結果（すべて Node 26.7.0 で実施）

```
node --version                      v26.7.0
yarn --version                      4.18.0
command -v corepack                 (空 = Node 26 は非同梱)
clean install + yarn install --immutable   OK（lock 変更なし）
yarn site:lint                      OK
yarn site:typecheck                 OK
nuxi build --preset github_pages    OK（884 ルート prerender）
yarn rss:generate                   OK（差分なし・DeprecationWarning なし）
tsc --noEmit（非 site 5パッケージ）  OK
```

`yarn api:generate` は AGENTS.md の運用ルール（`update_api` cron の管轄）に従い実行していない。`packages/site/public/api/` に差分がないことを確認済み。

## ⚠️ マージ後に確認が必要な残存リスク

**`update_api.yml` / `update_sns.yml`（cron）は CI で事前検証できない唯一の経路。** Node 26 は undici 8.0.2 を同梱し global `fetch` の実装が変わるが、`build.yml` / `deploy.yml` はコミット済み JSON を読むだけで GitHub API を叩かないため PR の CI では通らない。

→ **マージ後に `update_api.yml`（2時間おき cron）の初回実行を確認すること。**

また `build.yml` を2回走らせ、2回目の `Cache yarn packages` が `Cache restored from key: yarn-Linux-<hash>` になることも併せて確認したい（初回 miss は正常）。

## スコープ外

- `docs/plans/eslint-v10-migration.md:17` の `24.14.0` — ある時点の調査結果を記録した完了済みプラン文書のため据え置く
- `packages/sns-updater/tsconfig.json` の `target: es5` / `module: commonjs` — 本質的には直すべきだが今回の変更と結合が無く、型検査の厳格度が変わると Node 26 移行の green/red 判定にノイズが混じる。「sns-updater の tsconfig 統一」＋「非 site パッケージへの typecheck スクリプト / CI 追加」を独立 PR で扱うのが望ましい（現状 `typecheck` は `packages/site` にしか無く、他5パッケージは CI で型チェックされていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3bcqWvj8jSvSspPsVeuoG